### PR TITLE
fix: import MeasureGoalRoomType instead of MeasureDistDirTime in room goal environments

### DIFF
--- a/minos/config/envs/roomgoal_mp3d_m.py
+++ b/minos/config/envs/roomgoal_mp3d_m.py
@@ -1,4 +1,4 @@
-from minos.lib.util.measures import MeasureDistDirTime
+from minos.lib.util.measures import MeasureGoalRoomType
 
 config = {
     'task': 'room_goal',

--- a/minos/config/envs/roomgoal_mp3d_s.py
+++ b/minos/config/envs/roomgoal_mp3d_s.py
@@ -1,4 +1,4 @@
-from minos.lib.util.measures import MeasureDistDirTime
+from minos.lib.util.measures import MeasureGoalRoomType
 
 config = {
     'task': 'room_goal',

--- a/minos/config/envs/roomgoal_suncg_mf.py
+++ b/minos/config/envs/roomgoal_suncg_mf.py
@@ -1,4 +1,4 @@
-from minos.lib.util.measures import MeasureDistDirTime
+from minos.lib.util.measures import MeasureGoalRoomType
 
 config = {
     'task': 'room_goal',

--- a/minos/config/envs/roomgoal_suncg_sf.py
+++ b/minos/config/envs/roomgoal_suncg_sf.py
@@ -1,4 +1,4 @@
-from minos.lib.util.measures import MeasureDistDirTime
+from minos.lib.util.measures import MeasureGoalRoomType
 
 config = {
     'task': 'room_goal',


### PR DESCRIPTION
Hi all, I think the import statement in the room goal environments is false. 
I changed it from `MeasureDistDirTime` to `MeasureGoalRoomType`