### PR TITLE
Added flag termination_on_success for meas_fun

### DIFF
--- a/minos/config/envs/pointgoal_suncg_me_needs_report_success.py
+++ b/minos/config/envs/pointgoal_suncg_me_needs_report_success.py
@@ -1,0 +1,15 @@
+from minos.lib.util.measures import MeasureDistDirTime
+
+config = {
+    'task': 'point_goal',
+    'goal': {'type': 'position', 'type': 'position', 'position': 'random', 'radius': 0.25},
+    'measure_fun': MeasureDistDirTime(goal_dist_threshold=0.4, termination_on_success = False),
+    'reward_type': 'dist_time',
+    'agent': {'radialClearance': 0.2},
+    'scenes_file': '../data/scenes.multiroom.csv',
+    'states_file': '../data/episode_states.suncg.csv.bz2',
+    'scene': {'arch_only': False, 'retexture': True, 'empty_room': True, 'dataset': 'p5dScene'},
+    'scene_filter': lambda s: 2 < s['nrooms'] < 6,
+    'episode_filter': lambda e: e['pathNumDoors'] > 1,
+    'objective_size': 4 # For UNREAL
+}

--- a/minos/lib/util/measures.py
+++ b/minos/lib/util/measures.py
@@ -8,10 +8,12 @@ class Measure:
 
     def __init__(self, goal_dist_threshold=1.0e-6,  # success when dist < this value
                  termination_dist_value=-10.0,  # overrides distance value returned at term
-                 termination_time=50.0):
+                 termination_time=50.0,
+                 termination_on_success=True):
         self.goal_dist_threshold = goal_dist_threshold
         self.termination_dist_value = termination_dist_value
         self.termination_time = termination_time
+        self.termination_on_success = termination_on_success
 
     def reset(self):
         pass
@@ -40,7 +42,9 @@ class Measure:
         else:
             success = distances[0] <= self.goal_dist_threshold
 
-        term = success or time > self.termination_time
+        term = time > self.termination_time
+        if self.termination_on_success:
+            term = term or success
         return success, term
 
 


### PR DESCRIPTION
According to "On Evaluation of Embodied Navigation Agents" https://arxiv.org/abs/1807.06757 
I have added flag, that simulation does not automatically stop, when agent (randomly) reaches the goal. So agent should explicitly tell that it thinks, that goal is reached. 